### PR TITLE
Add explicit plexus-utils dep for minify plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,6 +216,13 @@
                 <groupId>com.samaxes.maven</groupId>
                 <artifactId>minify-maven-plugin</artifactId>
                 <version>1.7.6</version>
+                <dependencies>
+                  <dependency>
+                    <groupId>org.codehaus.plexus</groupId>
+                    <artifactId>plexus-utils</artifactId>
+                    <version>3.5.1</version>
+                  </dependency>
+                </dependencies>
                 <executions>
                     <execution>
                         <id>minify</id>


### PR DESCRIPTION
Maven since 3.9 no longer includes the plexus-utils dependency which the minify-maven-plugin depends on.
(https://maven.apache.org/docs/3.9.0/release-notes.html#potentially-breaking-core-changes)

Adding the explicit dependency is the quickest workaround.

Note that the https://github.com/samaxes/minify-maven-plugin version of the plugin hasn't been maintained for many years. There is a fork at https://github.com/sevenprinciples/minify-maven-plugin with updates which make it compatible with current maven versions but, it appears to have a dependency on a library which requires Java 11+ so can't be used here yet.

Fixes  #15 